### PR TITLE
Fix missing prereqs URI as reported by CPANTS.

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,5 @@
 requires 'Moo';
+requires 'URI';
 
 on 'test' => sub {
     requires 'Test::Most';


### PR DESCRIPTION
Hi @blabos 

Please review the PR.
http://cpants.cpanauthors.org/release/BLABOS/Paginator-Lite-2.001001

Many Thanks.
Best Regards,
Mohammad S Anwar